### PR TITLE
Fix error handling ++

### DIFF
--- a/app/mixins/attachable.js
+++ b/app/mixins/attachable.js
@@ -83,10 +83,13 @@ export default Ember.Mixin.create({
       store.didSaveRecord(record, payload);
       return record;
     }), (function(reason) {
-      if (reason.jqXHR && reason.jqXHR.status === 422) {
-        store.recordWasInvalid(record, reason.jqXHR.responseJSON.errors);
+      var error = adapter.ajaxError(reason.jqXHR);
+      if (error instanceof DS.InvalidError) {
+        store.recordWasInvalid(record, error.errors);
+      } else if (error.status === 422){
+        store.recordWasInvalid(record, error.responseJSON.errors);
       } else {
-        store.recordWasError(record, reason);
+        store.recordWasError(record);
       }
       throw reason;
     }), "Uploading file with attachment");

--- a/tests/dummy/app/adapters/post.js
+++ b/tests/dummy/app/adapters/post.js
@@ -1,0 +1,3 @@
+import DS from 'ember-data';
+
+export default DS.ActiveModelAdapter.extend();

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -1,0 +1,11 @@
+import DS from 'ember-data';
+import Attachable from '../mixins/attachable';
+
+export default DS.Model.extend(Attachable,{
+
+  attachment: 'photo',
+
+  title: DS.attr('string'),
+  photoUrl: DS.attr('string')
+
+});


### PR DESCRIPTION
Improves https://github.com/abuiles/ember-attachable/pull/8 and handles the case, when adapter other than `DS.RESTAdapter` is used (e. g. `DS.ActiveModelAdapter`). Can be merged after the aforementioned PR.