### PR TITLE
Include adapter headers in ajax request

### DIFF
--- a/app/mixins/attachable.js
+++ b/app/mixins/attachable.js
@@ -36,6 +36,7 @@ export default Ember.Mixin.create({
       type: this._requestType(),
       data: formData,
       dataType: 'json',
+      headers: adapter.get('headers'),
       processData: false,
       contentType: false,
       xhr: function() {


### PR DESCRIPTION
Currently, headers set on the adapter are ignored. This passes adapter headers along with the other request options.