### PR TITLE
Enable upload filename to be set

### DIFF
--- a/addon/mixins/attachable.js
+++ b/addon/mixins/attachable.js
@@ -32,12 +32,12 @@ export default Ember.Mixin.create({
       if (!Ember.isNone(data[key])) {
         if (Ember.isArray(data[key])) {
           return data[key].forEach(function(val) {
-            return formData.append("" + root + "[" + key + "][]", val);
+            return formData.append("" + root + "[" + key + "][]", val, val.filename || 'blob');
           });
         }else if(Object.prototype.toString.call(data[key]) === '[object Object]'){
           return _this._recursiveObjectAppend(formData,"" + root + "[" + key + "]",data,key);
         } else {
-          return formData.append("" + root + "[" + key + "]", data[key]);
+          return formData.append("" + root + "[" + key + "]", data[key], data[key].filename || 'blob');
         }
       }
     });


### PR DESCRIPTION
This PR addresses the filename issue I raised in https://github.com/abuiles/ember-attachable/issues/26

This is an example of how I'm allowing filenames to be set on an upload. Since JS let's us set arbitrary properties on a `Blob` object, we can simply do:

``` js
const imageBlob = new Blob([files[0]], { type: files[0].type });
imageBlob.filename = files[0].name;

myModel.set('image', imageBlob);
```

...and my PR code will detect that property, and use it when calling `formData.append`.
