### PR TITLE
fixed bug on createWithAttachment

### DIFF
--- a/addon/lib/serializer-response.js
+++ b/addon/lib/serializer-response.js
@@ -86,8 +86,8 @@ export function normalizeResponseHelper(serializer, store, modelClass, payload, 
 
     return normalizedResponse;
   }else{
-    var serializerPayload = serializer.extract(store, modelClass, payload, id, requestType);
-    return _normalizeSerializerPayload(modelClass, serializerPayload);
+    var serializerPayload = serializer.normalizeResponse(store, modelClass, payload, id, requestType);
+    return _normalizeSerializerPayload(modelClass, serializerPayload.data);
   }
 }
 

--- a/addon/mixins/attachable.js
+++ b/addon/mixins/attachable.js
@@ -40,7 +40,13 @@ export default Ember.Mixin.create({
       }
     });
 
-    url = adapter.buildURL(this._modelName(), this.get('id'));
+    if(this.get('isNew')){
+      url = adapter.buildURL(this._modelName(), this.get('id'), [], 'createRecord');
+    }
+    else{
+      url = adapter.buildURL(this._modelName(), this.get('id'), [], 'updateRecord');
+    }
+    
     if(this._oldEmberData()){
       this.adapterWillCommit();
     }else{


### PR DESCRIPTION
First of all, thanks for your work!

Im sending a quick fix on createWithAttachment. Probably, until now, nobody had this problem before.
On my local project I customised `urlForUpdateRecord` method. But since your code never sends the `requestType` parameter to `buildURL`, my custom `urlForUpdateRecord` was never called.

Best regards